### PR TITLE
It is funny on HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@
         
     <title>The right way of fixing software (and not only) bugs</title>
 
-    <link href='http://fonts.googleapis.com/css?family=Pacifico' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Slabo+27px' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Pacifico|Slabo+27px' rel='stylesheet' type='text/css'>
     <link href="css/fontawesome/css/font-awesome.min.css" rel="stylesheet">
     <link href="css/styles.css" rel="stylesheet">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />


### PR DESCRIPTION
On HTTPS the font style sheet doesn't load because it is a HTTP resource. As the result the fonts are rendered in the default cursive font, usually Comic Sans MS for some browser/OS setups. Fixed this by changing the protocol.

Also simplified it by loading just one style sheet.
